### PR TITLE
Specify parameters explicitly

### DIFF
--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -16,7 +16,7 @@ private def it_parses_and_eq(string_a, string_b, file = __FILE__, line = __LINE_
     parser_b = Parser.new string_b
     result_b = parser_b.parse
 
-    result_a.should eq(result_b), file, line
+    result_a.should eq(result_b), file: file, line: line
   end
 end
 


### PR DESCRIPTION
Fixes compilation error:
``` bash
In spec/parser_spec.cr:19:14

 19 | result_a.should eq(result_b), file, line
               ^-----
Error: wrong number of arguments for 'Hash(String, TOML::Type)#should' (given 3, expected 1..2)
```

Crystal version: 1.6.0

Similar to #29