### PR TITLE
Remove special-casing of old Crystal versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/crystal-community/toml.cr.png)](https://travis-ci.org/crystal-community/toml.cr)
 
-A [TOML](https://github.com/toml-lang/toml) parser for [Crystal](http://crystal-lang.org/), compliant with the v0.4.0 version of TOML.
+A [TOML](https://github.com/toml-lang/toml) parser for [Crystal](http://crystal-lang.org/), compliant with the v0.5.0 version of TOML.
 
 ## Installation
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: toml
 version: 0.7.0
 
-crystal: ">= 0.35.0"
+crystal: ">= 1.0.0"
 
 authors:
   - Ary Borenszweig <aborenszweig@manas.com.ar>

--- a/spec/lexer_spec.cr
+++ b/spec/lexer_spec.cr
@@ -152,12 +152,7 @@ describe Lexer do
   it_lexes_time "1979-05-27T07:32:00Z", Time.utc(1979, 5, 27, 7, 32, 0)
   it_lexes_time "1979-05-27T07:32:00-07:30", Time.utc(1979, 5, 27, 15, 2, 0)
   it_lexes_time "1979-05-27T07:32:00+07:30", Time.utc(1979, 5, 27, 0, 2, 0)
-  it_lexes_time "1979-05-27T07:32:00.999999-07:00",
-    {% if Crystal::VERSION =~ /^0\.(\d|1\d|2[0-3])\./ %}
-      Time.utc(1979, 5, 27, 14, 32, 0, 999)
-    {% else %}
-      Time.utc(1979, 5, 27, 14, 32, 0, nanosecond: 999999000)
-    {% end %}
+  it_lexes_time "1979-05-27T07:32:00.999999-07:00", Time.utc(1979, 5, 27, 14, 32, 0, nanosecond: 999999000)
 
   it "lexes multinline basic string" do
     lexer = Lexer.new(%("""hello"""))

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -16,7 +16,7 @@ private def it_parses_and_eq(string_a, string_b, file = __FILE__, line = __LINE_
     parser_b = Parser.new string_b
     result_b = parser_b.parse
 
-    result_a.should eq(result_b), file, line
+    result_a.should eq(result_b), file: file, line: line
   end
 end
 

--- a/src/toml/lexer.cr
+++ b/src/toml/lexer.cr
@@ -571,16 +571,7 @@ class TOML::Lexer
     end
 
     unless local_time
-      time =
-        {% if Crystal::VERSION =~ /^0\.(\d|1\d|2[0-3])\./ %}
-          Time.new(year, month, day, hour, minute, second, microseconds / 1000, kind: Time::Kind::Utc) # 0.23.x or lower
-        {% elsif Crystal::VERSION =~ /^0\.24\./ %}
-          Time.new(year, month, day, hour, minute, second, nanosecond: microseconds * 1000, kind: Time::Kind::Utc) # 0.24.x breaks arguments
-        {% elseif Crystal::VERSION =~ /^0\.2[5-7]\./ %}
-          Time.new(year.to_i32, month, day, hour, minute, second, nanosecond: microseconds * 1000, location: Time::Location::UTC) # 0.25.x breaks `Time::Kind`
-        {% else %}
-          Time.local(year.to_i32, month, day, hour, minute, second, nanosecond: microseconds * 1000, location: Time::Location::UTC) # 0.28 deprecated `Time.new`
-        {% end %}
+      time = Time.utc(year.to_i32, month, day, hour, minute, second, nanosecond: microseconds * 1000)
       time += (negative ? hour_offset : -hour_offset).hours if hour_offset
       time += (negative ? minute_offset : -minute_offset).minutes if minute_offset
     else

--- a/src/toml/token.cr
+++ b/src/toml/token.cr
@@ -18,12 +18,7 @@ class TOML::Token
     @string_value = ""
     @int_value = 0_i64
     @float_value = 0.0
-    @time_value =
-      {% if Crystal::VERSION =~ /^0\.(\d|1\d|2[0-7])\./ %}
-        Time.new(1, 1, 1)
-      {% else %}
-        Time.local # 2.8 deprecated `Time.new`
-      {% end %}
+    @time_value = Time.local
   end
 
   def to_s(io)


### PR DESCRIPTION
Also update the min version to Crystal `1.0.0`.

`0.35.0` was released over 3 years ago, it's probably time that this shard removed special-casing for these old versions.